### PR TITLE
switch to binance.us as opposed to binance.com

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
         version: v1.29

--- a/api/config.toml
+++ b/api/config.toml
@@ -22,7 +22,7 @@ rateLimit = 5
 rateLimitPeriod = "1s"
 
 [binance]
-baseUri = "https://api.binance.com"
+baseUri = "https://api.binance.us"
 candlesEndpoint = "/api/v3/klines"
 currentPriceEndpoint = "/api/v3/avgPrice"
 apiKey = "RX3KCdKk4gn095ljB1UJoezVL7OdUo9LeqEdeX7JySk7MKLkQHNN5VWMOC4Or8ek"


### PR DESCRIPTION
Logs show that we started getting a 451 response from binance:
```javascript
{
    "level": "error",
    "msg": "Something went terribly wrong: %wcould not determine currency rates: something went terribly wrong with Binance networking: expected 2XX but instead got a 451",
    "time": "2023-01-08T19:42:04Z"
}

```

It seems that for legal reasons Binance stopped accepting requests from US locations to `api.binance.com`. This theory makes sense because bscfees.com is hosted in aws us-east-1 region. According to [this](https://dev.binance.vision/t/api-error-451-unavailable-for-legal-reasons/13828/18) thread, switching our requests to target `api.binance.us`, will fix it. 